### PR TITLE
feat: enable smooth orbit damping on Explore tab graph

### DIFF
--- a/client/src/components/tabs/Explore.tsx
+++ b/client/src/components/tabs/Explore.tsx
@@ -433,7 +433,7 @@ const Explore = () => {
               | undefined;
             if (controls) {
               controls.enableDamping = true;
-              controls.dampingFactor = 0.12;
+              controls.dampingFactor = 0.06;
             }
           }}
         />


### PR DESCRIPTION
Enables `enableDamping` with `dampingFactor: 0.12` on the Three.js OrbitControls via `onEngineStop`, giving orbiting a smooth inertia feel.

Closes #8