### PR TITLE
fix: allow tooltip text wrapping and remove truncation

### DIFF
--- a/client/src/components/tabs/Explore.tsx
+++ b/client/src/components/tabs/Explore.tsx
@@ -184,8 +184,10 @@ const useStyles = makeStyles({
     border: "1px solid rgba(255,255,255,0.1)",
     fontSize: "12px",
     color: "#fff",
-    maxWidth: "260px",
-    whiteSpace: "nowrap",
+    maxWidth: "300px",
+    whiteSpace: "normal",
+    wordBreak: "break-word",
+    lineHeight: "1.4",
   },
 });
 
@@ -302,7 +304,7 @@ const Explore = () => {
           const screen = fgRef.current?.graph2ScreenCoords(mx, my, mz);
           if (screen) {
             setHoverTooltip({
-              text: desc.length > 80 ? desc.slice(0, 80) + "…" : desc,
+              text: desc,
               x: screen.x,
               y: screen.y,
             });


### PR DESCRIPTION
Fixes #10

- Changed tooltip whiteSpace from 
owrap to 
ormal so long text wraps
- Added wordBreak: break-word and lineHeight: 1.4 for clean multi-line display
- Bumped maxWidth from 260px to 300px
- Removed 80-char hard truncation on link description tooltips