### PR TITLE
docs: update documentation for Explore and Build tabs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,11 +20,14 @@ React + Vite client (`client/`) with Fluent UI v9, backed by a FastAPI server (`
 
 ### Server (`server/`)
 
-FastAPI application with three routers:
+FastAPI application with six routers:
 
 - **Query** (`endpoints/query.py`) — SSE streaming endpoints for RAG and GraphRAG search
 - **Questions** (`endpoints/questions.py`) — AI-generated question suggestions
 - **Evaluate** (`endpoints/evaluate.py`) — Response quality scoring via Azure AI Evaluation SDK
+- **Graph** (`endpoints/graph.py`) — Pre-indexed knowledge graph data for the Explore tab
+- **Build** (`endpoints/build.py`) — End-to-end pipeline: memo generation, indexing, querying, and evaluation
+- **Feedback** (`endpoints/feedback.py`) — User feedback collection
 
 ### Query Pipeline
 
@@ -40,12 +43,14 @@ FastAPI application with three routers:
 
 ### Evaluation Pipeline
 
-Uses Azure AI Evaluation SDK (`azure-ai-evaluation`) with three evaluators run in parallel per response:
+Uses Azure AI Evaluation SDK (`azure-ai-evaluation`) with five evaluators:
 - **RelevanceEvaluator** — does the response answer the question?
-- **GroundednessEvaluator** — are claims supported by source text?
 - **CoherenceEvaluator** — is the response well-structured and logical?
+- **GroundednessEvaluator** — are claims supported by source text?
+- **SimilarityEvaluator** — how similar are the RAG and GraphRAG responses?
+- **RetrievalEvaluator** — quality of the retrieved source documents
 
-Scores are 1–5, normalized to 0–100% and averaged for an overall score. Each side (RAG/GraphRAG) evaluates independently as soon as its stream finishes.
+Scores are 1–5, normalized to 0–100%. The Ask tab evaluates in two phases: quick (relevance + coherence) fires per-pipeline as soon as streaming completes, then full (groundedness + similarity + retrieval) fires once both pipelines finish. The Build tab evaluates all five metrics in a single pass after each query.
 
 ### SSE Streaming Protocol
 
@@ -53,23 +58,34 @@ Server emits SSE events with `data:` lines. Newlines within a chunk are encoded 
 
 ### API Endpoints
 
-| Method | Endpoint                    | Purpose                                      |
-| ------ | --------------------------- | -------------------------------------------- |
-| POST   | `/api/query/rag`            | Stream RAG answer via SSE                    |
-| POST   | `/api/query/graphrag`       | Stream GraphRAG answer via SSE               |
-| GET    | `/api/questions/ask`        | AI-generated question suggestions            |
-| POST   | `/api/evaluate/single`      | Evaluate a single response (3 metrics)       |
-| POST   | `/api/evaluate`             | Evaluate both RAG + GraphRAG responses       |
-| GET    | `/api/graph/explore`        | Full graph for 3D visualization              |
-| POST   | `/api/build/generate`       | Foundry agent memo generation                |
-| POST   | `/api/build/index`          | Trigger GraphRAG indexing pipeline           |
-| POST   | `/api/build/questions`      | Generate questions from new graph            |
-| POST   | `/api/build/query`          | Query the build-tab graph                    |
+| Method | Endpoint                       | Purpose                                      |
+| ------ | ------------------------------ | -------------------------------------------- |
+| POST   | `/api/query/rag`               | Stream RAG answer via SSE                    |
+| POST   | `/api/query/graphrag`          | Stream GraphRAG answer via SSE               |
+| GET    | `/api/questions/ask`           | AI-generated question suggestions            |
+| POST   | `/api/evaluate/quick`          | Quick eval: relevance + coherence            |
+| POST   | `/api/evaluate/full`           | Full eval: groundedness + similarity + retrieval |
+| GET    | `/api/graph/explore`           | Full graph for 3D visualization              |
+| POST   | `/api/build/generate`          | Foundry agent memo generation                |
+| POST   | `/api/build/index`             | Trigger GraphRAG indexing pipeline (SSE progress) |
+| GET    | `/api/build/graph/{session_id}`| Fetch indexed graph for a build session      |
+| POST   | `/api/build/questions`         | Generate questions from new graph            |
+| POST   | `/api/build/query`             | Query the build-tab graph via SSE            |
+| POST   | `/api/build/evaluate`          | Evaluate a build query response (5 metrics)  |
+| POST   | `/api/build/reset`             | Reset and clean up a build session           |
+| POST   | `/api/feedback`                | Submit user feedback                         |
 
 ### Client Architecture
 
-- **API layer** (`src/api/ask.api.ts`) — SSE consumption with `consumeSSE()` helper, streaming callbacks, and `AbortController` for cancellation
-- **Hooks** (`src/hooks/ask.hooks.ts`) — `useStreamingQuery()` manages concurrent stream state, TTFT measurement (via `performance.now()` refs), token estimation (~4 chars/token), and auto-triggered per-side evaluation
+- **API layer** (`src/api/`) — SSE consumption with `consumeSSE()` helper, streaming callbacks, and `AbortController` for cancellation
+  - `ask.api.ts` — RAG/GraphRAG streaming, question fetching, phased evaluation
+  - `explore.api.ts` — Pre-built graph data fetching
+  - `build.api.ts` — Memo generation, indexing with SSE progress, build-tab querying and evaluation
+- **Hooks** (`src/hooks/`)
+  - `ask.hooks.ts` — `useStreamingQuery()` manages concurrent stream state, TTFT measurement (via `performance.now()` refs), token estimation (~4 chars/token), and auto-triggered per-side evaluation
+  - `explore.hooks.ts` — `useExploreGraph()` fetches and caches graph data via TanStack Query
+  - `build.hooks.ts` — `useBuildWizard()` orchestrates the full build pipeline (scenario → generate → index → query → evaluate) with localStorage persistence
+  - `storage.ts` — localStorage persistence helpers
 - **Markdown rendering** — `react-markdown` with `remark-gfm` for GFM tables, strikethrough, and task lists
 
 ### Stack

--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ See [rag/README.md](rag/README.md) for the Azure AI Search indexing setup.
 
 ### Evaluation
 
-The app evaluates responses in two phases using the Azure AI Evaluation SDK:
+The app evaluates responses using the Azure AI Evaluation SDK with five metrics: relevance, coherence, groundedness, similarity, and retrieval.
 
-- **Quick** (per-pipeline): Relevance + Coherence —> runs as soon as a response finishes streaming.
-- **Full** (both pipelines): Groundedness + Similarity + Retrieval —> runs once both RAG and GraphRAG complete, using GraphRAG as the ground truth.
+- **Ask tab** — two-phase evaluation:
+  - **Quick** (per-pipeline): Relevance + Coherence → runs as soon as a response finishes streaming.
+  - **Full** (both pipelines): Groundedness + Similarity + Retrieval → runs once both RAG and GraphRAG complete, using GraphRAG as the ground truth.
+- **Build tab** — single-pass evaluation: all five metrics run together after each query.
 
-Scores appear as badges next to each response in the Ask tab. See [eval/README.md](eval/README.md) for batch eval scripts and dataset details.
+Scores appear as badges next to each response. See [eval/README.md](eval/README.md) for batch eval scripts and dataset details.
 
 ## Additional Details
 

--- a/client/README.md
+++ b/client/README.md
@@ -18,11 +18,11 @@ src/
   api/
     ask.api.ts               # SSE streaming, eval API calls
     explore.api.ts           # Graph data fetching
-    build.api.ts             # Memo generation + indexing
+    build.api.ts             # Memo generation, indexing, build querying + eval
   hooks/
     ask.hooks.ts             # Streaming state, phased eval orchestration
     explore.hooks.ts         # Graph data hook
-    build.hooks.ts           # Build pipeline hook
+    build.hooks.ts           # Build pipeline wizard hook
     storage.ts               # localStorage persistence helpers
   components/
     Header.tsx               # Navigation header
@@ -30,10 +30,16 @@ src/
       QueryInput.tsx         # Search input with suggestion pills
       QueryPanel.tsx         # Markdown response panel with streaming
       EvalBadge.tsx          # Evaluation score badge with tooltip
+      FoundryLogo.tsx        # Foundry SVG logo component
+    build/
+      ScenarioSelector.tsx   # Scenario cards + memo count slider
+      MemoList.tsx           # Accordion of generated memos + index button
+      BuildGraph.tsx         # 3D graph preview of indexed entities
+      BuildQueryPanel.tsx    # Query input, question suggestions, responses, eval badges
     tabs/
       Ask.tsx                # Ask tab layout (two-panel + metrics)
-      Explore.tsx            # Explore tab (3D graph)
-      Build.tsx              # Build tab (pipeline wizard)
+      Explore.tsx            # Explore tab (3D graph + detail drawers)
+      Build.tsx              # Build tab (pipeline wizard + graph + query)
 ```
 
 ## Setup

--- a/server/README.md
+++ b/server/README.md
@@ -4,14 +4,23 @@ FastAPI backend serving query, evaluation, and question generation endpoints.
 
 ## Endpoints
 
-| Route                 | Method | Description                                      |
-| --------------------- | ------ | ------------------------------------------------ |
-| `/`                   | GET    | Health check                                     |
-| `/api/query/rag`      | POST   | Stream RAG response (SSE)                        |
-| `/api/query/graphrag` | POST   | Stream GraphRAG response (SSE)                   |
-| `/api/questions/ask`  | GET    | Generate AI-powered sample questions             |
-| `/api/evaluate/quick` | POST   | Quick eval: relevance + coherence                |
-| `/api/evaluate/full`  | POST   | Full eval: groundedness + similarity + retrieval |
+| Route                          | Method | Description                                      |
+| ------------------------------ | ------ | ------------------------------------------------ |
+| `/`                            | GET    | Health check                                     |
+| `/api/query/rag`               | POST   | Stream RAG response (SSE)                        |
+| `/api/query/graphrag`          | POST   | Stream GraphRAG response (SSE)                   |
+| `/api/questions/ask`           | GET    | Generate AI-powered sample questions             |
+| `/api/evaluate/quick`          | POST   | Quick eval: relevance + coherence                |
+| `/api/evaluate/full`           | POST   | Full eval: groundedness + similarity + retrieval |
+| `/api/graph/explore`           | GET    | Pre-indexed knowledge graph for Explore tab      |
+| `/api/build/generate`          | POST   | Generate synthetic memos via Foundry agent       |
+| `/api/build/index`             | POST   | Run GraphRAG indexing pipeline (SSE progress)    |
+| `/api/build/graph/{session_id}`| GET    | Fetch indexed graph for a build session          |
+| `/api/build/questions`         | POST   | Generate questions from the build graph          |
+| `/api/build/query`             | POST   | Query the build graph via SSE                    |
+| `/api/build/evaluate`          | POST   | Evaluate a build query response (5 metrics)      |
+| `/api/build/reset`             | POST   | Reset and clean up a build session               |
+| `/api/feedback`                | POST   | Submit user feedback                             |
 
 ## Structure
 
@@ -24,10 +33,14 @@ server/
     query.py               # RAG + GraphRAG SSE streaming endpoints
     evaluate.py            # Phased evaluation (quick + full)
     questions.py           # AI-generated question suggestions
+    graph.py               # Pre-indexed graph data for Explore tab
+    build.py               # Build pipeline: generate, index, query, evaluate, reset
+    feedback.py            # User feedback endpoint
   utils/
     rag_query.py           # Azure AI Search hybrid retrieval + GPT-4.1 streaming
     graphrag_query.py      # GraphRAG engine selection + streaming (global/local/drift)
     graphrag_questions.py  # Question generation from community reports
+    build_pipeline.py      # Memo generation, indexing workspace management
   output/                  # GraphRAG parquet tables (entities, communities, etc.)
 ```
 


### PR DESCRIPTION
## Summary

Updates all user-facing documentation to reflect the Explore tab, Build tab, and supporting endpoints added since the last docs pass.

### Changes

| File | Updates |
|---|---|
| `BUILD.md` | Fix router count (3->6), fix endpoint table (rename + add 6 missing routes), expand eval section (3->5 evaluators with per-tab phasing), add build/explore client architecture |
| `client/README.md` | Add `build/` components, `FoundryLogo.tsx`, missing API/hook files to structure tree |
| `server/README.md` | Add 9 missing endpoint rows (build, graph, feedback), add missing files to structure tree |
| `README.md` | Update evaluation section to cover both Ask tab two-phase and Build tab single-pass evaluation |

Closes #16