### PR TITLE
fix: Explore tab drawer panel not opening

### DIFF
--- a/client/src/components/tabs/Explore.tsx
+++ b/client/src/components/tabs/Explore.tsx
@@ -51,13 +51,14 @@ const useStyles = makeStyles({
   },
   graphContainer: {
     flex: 1,
+    minWidth: 0,
     position: "relative",
+    overflow: "hidden",
   },
   drawer: {
     backgroundColor: "#1e1e1e",
     borderLeft: "1px solid rgba(255,255,255,0.08)",
-    width: "380px",
-    maxWidth: "380px",
+    minWidth: "380px",
   },
   drawerClose: {
     display: "flex",
@@ -457,7 +458,6 @@ const Explore = () => {
       <InlineDrawer
         open={drawerOpen}
         position="end"
-        size="medium"
         className={styles.drawer}
         separator
       >


### PR DESCRIPTION
## Summary

Fixes the Explore tab detail drawer that stopped opening after the previous width fix (`1e4edaf`).

### Root Cause

The previous commit added `size="medium"` and a fixed `width: 380px` to the drawer. The `ForceGraph3D` canvas inside the `flex: 1` graph container was still rendering at full viewport width, pushing the drawer off-screen.

### Fix

- **Drawer**: replaced fixed `width`/`maxWidth` with `minWidth: 380px` so it can't be squished but doesn't fight the layout
- **Graph container**: added `minWidth: 0` + `overflow: hidden` so the flex child properly shrinks when the drawer opens
- Removed the `size="medium"` prop that was unnecessary