### PR TITLE
fix: Build tab graph links disconnected from nodes

### DIFF
--- a/client/src/components/build/BuildGraph.tsx
+++ b/client/src/components/build/BuildGraph.tsx
@@ -166,11 +166,23 @@ const BuildGraph = ({ data }: Props) => {
     );
   }
 
+  // Deep-clone graph data so ForceGraph3D's in-place mutations
+  // (replacing source/target strings with object refs) don't corrupt
+  // the React state or localStorage persistence.
+  const graphData = useMemo(
+    () => ({
+      nodes: data.nodes.map((n) => ({ ...n })),
+      links: data.links.map((l) => ({ ...l })),
+      communities: data.communities.map((c) => ({ ...c })),
+    }),
+    [data],
+  );
+
   return (
     <div className={styles.root} ref={containerRef} onMouseMove={handleMouseMove}>
       <ForceGraph3D
         ref={fgRef}
-        graphData={data}
+        graphData={graphData}
         width={dimensions.width || undefined}
         height={dimensions.height || undefined}
         backgroundColor="#151515"


### PR DESCRIPTION
## Summary

Fixes the Build tab knowledge graph where links cluster at the center disconnected from nodes.

### Root Cause

`react-force-graph-3d` mutates graph data **in place** - it replaces `source`/`target` string IDs with object references to the actual node objects. When this mutated data is persisted to localStorage (via the build wizard's state persistence) and later deserialized, `source`/`target` become serialized objects instead of ID strings, breaking node-link matching.

### Fix

Deep-clone the graph data via `useMemo` before passing it to `ForceGraph3D`, so the library's mutations never touch the React state or localStorage data.