### PR TITLE
revert: undo Build tab graph deep-clone changes from PR #19

### DIFF
--- a/client/src/components/build/BuildGraph.tsx
+++ b/client/src/components/build/BuildGraph.tsx
@@ -166,23 +166,11 @@ const BuildGraph = ({ data }: Props) => {
     );
   }
 
-  // Deep-clone graph data so ForceGraph3D's in-place mutations
-  // (replacing source/target strings with object refs) don't corrupt
-  // the React state or localStorage persistence.
-  const graphData = useMemo(
-    () => ({
-      nodes: data.nodes.map((n) => ({ ...n })),
-      links: data.links.map((l) => ({ ...l })),
-      communities: data.communities.map((c) => ({ ...c })),
-    }),
-    [data],
-  );
-
   return (
     <div className={styles.root} ref={containerRef} onMouseMove={handleMouseMove}>
       <ForceGraph3D
         ref={fgRef}
-        graphData={graphData}
+        graphData={data}
         width={dimensions.width || undefined}
         height={dimensions.height || undefined}
         backgroundColor="#151515"


### PR DESCRIPTION
Reverts the deep-clone `useMemo` added in PR #19 which introduced a hooks order violation that crashes the Build tab. Also closes PR #20 which attempted to fix the same issue.