### PR TITLE
feat: set client container app minReplicas to 1 for always-warm deployment

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -121,7 +121,7 @@ azure/
 
 Key design choices:
 
-- **Server** has `minReplicas: 1` (always warm), **client** has `minReplicas: 0` (scales to zero when idle).
+- Both **server** and **client** have `minReplicas: 1` (always warm) to avoid cold-start latency.
 - **GraphRAG data** (parquet + LanceDB, ~9 MB) is baked into the server Docker image.
 - **Runtime API URL injection** — the client nginx entrypoint replaces the default API URL with the actual server FQDN at container startup.
 - **RBAC is auto-assigned** — Cognitive Services OpenAI User, Search Index Data Reader/Contributor, Storage Blob Data Contributor.

--- a/azure/main.bicep
+++ b/azure/main.bicep
@@ -129,6 +129,7 @@ module clientApp 'modules/container-app.bicep' = {
       { name: 'API_BASE_URL', value: 'https://${serverApp.outputs.fqdn}/api' }
     ]
     secrets: []
+    minReplicas: 1
   }
 }
 

--- a/azure/main.json
+++ b/azure/main.json
@@ -817,6 +817,9 @@
           },
           "secrets": {
             "value": []
+          },
+          "minReplicas": {
+            "value": 1
           }
         },
         "template": {


### PR DESCRIPTION
Set client container app to always have 1 replica running (minReplicas: 1) to avoid cold-start latency.

### Changes
- **azure/main.bicep** — added minReplicas: 1 to client module params
- **azure/main.json** — added matching minReplicas parameter in ARM template
- **azure/README.md** — updated docs to reflect both apps are always warm